### PR TITLE
Build the provider for OpenBSD

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,6 +18,7 @@ builds:
       - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
     goos:
       - freebsd
+      - openbsd
       - windows
       - linux
       - darwin


### PR DESCRIPTION
Hello, this PR adds OpenBSD to the list of target operating systems that `goreleaser` uses to build the provider.

I have successfully used a locally compiled version of the provider on OpenBSD 7.6 (under the `amd64` architecture) to confirm it works.