### PR TITLE
Allow null MX records (.) in hostname validator trailing dot check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The provider's `container_api_url` configuration has been removed, as the comput
 
 ### Added
 - resource `dns_record`: support `SVCB`, `HTTPS` and `TLSA` types;
+- resource `dns_record`: support [Null MX](https://www.rfc-editor.org/rfc/rfc7505.html) ([#74](https://github.com/BunnyWay/terraform-provider-bunnynet/pull/74));
 
 ### Fixed
 - resource `compute_container_app`: fix flaky "attribute was null" error;

--- a/internal/dnsrecordresourcevalidator/hostname.go
+++ b/internal/dnsrecordresourcevalidator/hostname.go
@@ -38,13 +38,13 @@ func (v hostnameValidator) ValidateResource(ctx context.Context, req resource.Va
 
 	rType := planType.ValueString()
 	value := planValue.ValueString()
-	isNullMXRecord := rType == "MX" && value == "."
 
 	if len(value) == 0 {
 		resp.Diagnostics.Append(diag.NewAttributeErrorDiagnostic(valueAttr, "Invalid attribute configuration", "Attribute cannot be empty"))
 		return
 	}
 
+	isNullMXRecord := rType == "MX" && value == "."
 	valueIsHostname := rType == "CNAME" || rType == "MX" || rType == "NS" || rType == "PTR" || rType == "SRV"
 	if valueIsHostname && !isNullMXRecord && value[len(value)-1] == '.' {
 		resp.Diagnostics.Append(diag.NewAttributeErrorDiagnostic(valueAttr, "Invalid attribute configuration", v.Description(ctx)))

--- a/internal/dnsrecordresourcevalidator/hostname_test.go
+++ b/internal/dnsrecordresourcevalidator/hostname_test.go
@@ -48,7 +48,7 @@ func TestHostname(t *testing.T) {
 			ExpectedError: false,
 			PlanValues: map[string]tftypes.Value{
 				"type":  tftypes.NewValue(tftypes.String, "MX"),
-				"value": tftypes.NewValue(tftypes.String, "."),
+				"value": tftypes.NewValue(tftypes.String, "mail.example.com"),
 			},
 		},
 		{
@@ -56,6 +56,27 @@ func TestHostname(t *testing.T) {
 			PlanValues: map[string]tftypes.Value{
 				"type":  tftypes.NewValue(tftypes.String, "MX"),
 				"value": tftypes.NewValue(tftypes.String, "mail.example.com."),
+			},
+		},
+		{
+			ExpectedError: false,
+			PlanValues: map[string]tftypes.Value{
+				"type":  tftypes.NewValue(tftypes.String, "MX"),
+				"value": tftypes.NewValue(tftypes.String, "."),
+			},
+		},
+		{
+			ExpectedError: false,
+			PlanValues: map[string]tftypes.Value{
+				"type":  tftypes.NewValue(tftypes.String, "TXT"),
+				"value": tftypes.NewValue(tftypes.String, "."),
+			},
+		},
+		{
+			ExpectedError: true,
+			PlanValues: map[string]tftypes.Value{
+				"type":  tftypes.NewValue(tftypes.String, "CNAME"),
+				"value": tftypes.NewValue(tftypes.String, "."),
 			},
 		},
 	}


### PR DESCRIPTION
- Exempt MX value "." from trailing dot rejection
- Per established standard approach to protect domains that do not send email
  - https://www.gov.uk/guidance/protect-domains-that-dont-send-email#create-a-null-mx-record
- Add tests for allowed null MX and rejected trailing dot MX hostnames

Closes https://github.com/BunnyWay/terraform-provider-bunnynet/issues/75