### PR TITLE
resource pullzone: add existing_id to adopt auto-created pull zones

### DIFF
--- a/internal/provider/resource_pullzone.go
+++ b/internal/provider/resource_pullzone.go
@@ -54,6 +54,7 @@ type PullzoneResource struct {
 
 type PullzoneResourceModel struct {
 	Id                                 types.Int64   `tfsdk:"id"`
+	ExistingId                         types.Int64   `tfsdk:"existing_id"`
 	Name                               types.String  `tfsdk:"name"`
 	CdnDomain                          types.String  `tfsdk:"cdn_domain"`
 	DisableLetsEncrypt                 types.Bool    `tfsdk:"disable_letsencrypt"`
@@ -265,10 +266,28 @@ func (r *PullzoneResource) Schema(ctx context.Context, req resource.SchemaReques
 				},
 				Description: "The unique ID of the pull zone.",
 			},
+			"existing_id": schema.Int64Attribute{
+				Optional: true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.RequiresReplace(),
+					int64planmodifier.UseStateForUnknown(),
+				},
+				Description: "Adopt an existing pull zone by ID instead of creating a new one. Useful for managing auto-created pull zones from accelerated DNS records. When set, the resource will update the existing pull zone's settings instead of creating a new one, and will not delete it on destroy.",
+			},
 			"name": schema.StringAttribute{
-				Required: true,
+				Optional: true,
+				Computed: true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.RequiresReplaceIf(
+						func(ctx context.Context, req planmodifier.StringRequest, resp *stringplanmodifier.RequiresReplaceIfFuncResponse) {
+							var existingId types.Int64
+							req.Plan.GetAttribute(ctx, path.Root("existing_id"), &existingId)
+							resp.RequiresReplace = existingId.IsNull() || existingId.IsUnknown()
+						},
+						"Name changes require replacement only when not adopting an existing pull zone.",
+						"Name changes require replacement only when not adopting an existing pull zone.",
+					),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 				Validators: []validator.String{
 					stringvalidator.LengthAtLeast(1),
@@ -1222,6 +1241,7 @@ func (r *PullzoneResource) Schema(ctx context.Context, req resource.SchemaReques
 					"url": schema.StringAttribute{
 						CustomType:  customtype.PullzoneOriginUrlType{},
 						Optional:    true,
+						Computed:    true,
 						Description: "The origin URL from where the files are fetched.",
 					},
 					"storagezone": schema.Int64Attribute{
@@ -1357,6 +1377,7 @@ func (r *PullzoneResource) ConfigValidators(ctx context.Context) []resource.Conf
 		pullzoneresourcevalidator.Origin(),
 		pullzoneresourcevalidator.PermacacheCacheExpirationTime(),
 		pullzoneresourcevalidator.CacheStaleBackgroundUpdate(),
+		pullzoneresourcevalidator.NameOrExistingId(),
 	}
 }
 
@@ -1382,6 +1403,44 @@ func (r *PullzoneResource) Create(ctx context.Context, req resource.CreateReques
 	var dataTf PullzoneResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &dataTf)...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !dataTf.ExistingId.IsNull() && !dataTf.ExistingId.IsUnknown() {
+		// Adopt an existing pull zone instead of creating a new one.
+		existingId := dataTf.ExistingId.ValueInt64()
+
+		existing, err := r.client.GetPullzone(existingId)
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to find existing pullzone", fmt.Sprintf("Pull zone %d not found: %s", existingId, err.Error()))
+			return
+		}
+
+		// Use the existing pull zone's ID and name.
+		dataTf.Id = types.Int64Value(existing.Id)
+		if dataTf.Name.IsNull() || dataTf.Name.IsUnknown() {
+			dataTf.Name = types.StringValue(existing.Name)
+		}
+
+		// Update the existing pull zone with the desired settings.
+		dataApi := r.convertModelToApi(ctx, dataTf)
+		pzMutex.Lock(existingId)
+		dataApi, err = r.client.UpdatePullzone(dataApi)
+		pzMutex.Unlock(existingId)
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to update adopted pullzone", err.Error())
+			return
+		}
+
+		tflog.Trace(ctx, fmt.Sprintf("adopted pullzone %d (%s)", dataApi.Id, dataApi.Name))
+		dataTf, diags := r.convertApiToModel(dataApi)
+		if diags != nil {
+			resp.Diagnostics.Append(diags...)
+			return
+		}
+
+		dataTf.ExistingId = types.Int64Value(existingId)
+		resp.Diagnostics.Append(resp.State.Set(ctx, &dataTf)...)
 		return
 	}
 
@@ -1429,6 +1488,9 @@ func (r *PullzoneResource) Read(ctx context.Context, req resource.ReadRequest, r
 		resp.Diagnostics.Append(diags...)
 		return
 	}
+
+	// Preserve existing_id from state since it is not part of the API model.
+	dataTf.ExistingId = data.ExistingId
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &dataTf)...)
 }
@@ -1501,6 +1563,9 @@ func (r *PullzoneResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
+	// Preserve existing_id from plan since it is not part of the API model.
+	dataTf.ExistingId = data.ExistingId
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &dataTf)...)
 }
 
@@ -1508,6 +1573,12 @@ func (r *PullzoneResource) Delete(ctx context.Context, req resource.DeleteReques
 	var data PullzoneResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !data.ExistingId.IsNull() {
+		// Adopted pull zone — the DNS record owns its lifecycle, so skip deletion.
+		tflog.Info(ctx, fmt.Sprintf("Skipping deletion of adopted pull zone %d", data.Id.ValueInt64()))
 		return
 	}
 

--- a/internal/provider/resource_pullzone_test.go
+++ b/internal/provider/resource_pullzone_test.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -80,6 +81,80 @@ func TestAccPullzoneWithPermacacheResource(t *testing.T) {
 					resource.TestCheckResourceAttr("bunnynet_pullzone.test", "name", fmt.Sprintf("test-acceptance-%s", testKey)),
 					resource.TestCheckResourceAttr("bunnynet_pullzone.test", "cache_expiration_time", "31919000"),
 				),
+			},
+		},
+	})
+}
+
+const configPullzoneExistingIdTest = `
+data "bunnynet_dns_zone" "domain" {
+  domain = "terraform.internal"
+}
+
+resource "bunnynet_dns_record" "accelerated" {
+  zone        = data.bunnynet_dns_zone.domain.id
+  name        = "test-adopt-%s"
+  type        = "CNAME"
+  value       = "example.com"
+  accelerated = true
+}
+
+resource "bunnynet_pullzone" "adopted" {
+  existing_id = bunnynet_dns_record.accelerated.accelerated_pullzone
+
+  origin {
+    type = "DnsAccelerate"
+  }
+
+  routing {
+    tier = "Standard"
+  }
+
+  cache_enabled = true
+}
+`
+
+func TestAccPullzoneExistingIdResource(t *testing.T) {
+	testKey := generateRandomString(12)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(configPullzoneExistingIdTest, testKey),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("bunnynet_pullzone.adopted", "id"),
+					resource.TestCheckResourceAttrSet("bunnynet_pullzone.adopted", "name"),
+					resource.TestCheckResourceAttrSet("bunnynet_pullzone.adopted", "existing_id"),
+					resource.TestCheckResourceAttr("bunnynet_pullzone.adopted", "cache_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+const configPullzoneNoNameNoExistingId = `
+resource "bunnynet_pullzone" "test" {
+  origin {
+    type = "OriginUrl"
+    url = "https://bunny.net"
+  }
+
+  routing {
+    tier = "Standard"
+  }
+}
+`
+
+func TestAccPullzoneNoNameNoExistingId(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      configPullzoneNoNameNoExistingId,
+				ExpectError: regexp.MustCompile(`Either "name" or "existing_id" must be configured`),
 			},
 		},
 	})

--- a/internal/pullzoneresourcevalidator/name_or_existing_id.go
+++ b/internal/pullzoneresourcevalidator/name_or_existing_id.go
@@ -1,0 +1,47 @@
+// Copyright (c) BunnyWay d.o.o.
+// SPDX-License-Identifier: MPL-2.0
+
+package pullzoneresourcevalidator
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func NameOrExistingId() resource.ConfigValidator {
+	return nameOrExistingIdValidator{}
+}
+
+type nameOrExistingIdValidator struct{}
+
+func (v nameOrExistingIdValidator) Description(ctx context.Context) string {
+	return "Either \"name\" or \"existing_id\" must be set."
+}
+
+func (v nameOrExistingIdValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v nameOrExistingIdValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var name types.String
+	req.Config.GetAttribute(ctx, path.Root("name"), &name)
+
+	var existingId types.Int64
+	req.Config.GetAttribute(ctx, path.Root("existing_id"), &existingId)
+
+	if name.IsUnknown() || existingId.IsUnknown() {
+		return
+	}
+
+	nameSet := !name.IsNull()
+	existingIdSet := !existingId.IsNull()
+
+	if !nameSet && !existingIdSet {
+		resp.Diagnostics.AddError(
+			"Missing required attribute",
+			"Either \"name\" or \"existing_id\" must be configured.",
+		)
+	}
+}

--- a/internal/pullzoneresourcevalidator/name_or_existing_id_test.go
+++ b/internal/pullzoneresourcevalidator/name_or_existing_id_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) BunnyWay d.o.o.
+// SPDX-License-Identifier: MPL-2.0
+
+package pullzoneresourcevalidator
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"testing"
+)
+
+func TestNameOrExistingId(t *testing.T) {
+	type testCase struct {
+		ExpectedError bool
+		PlanValues    map[string]tftypes.Value
+	}
+
+	testCases := []testCase{
+		{
+			ExpectedError: false,
+			PlanValues: map[string]tftypes.Value{
+				"name":        tftypes.NewValue(tftypes.String, "my-pullzone"),
+				"existing_id": tftypes.NewValue(tftypes.Number, nil),
+			},
+		},
+		{
+			ExpectedError: false,
+			PlanValues: map[string]tftypes.Value{
+				"name":        tftypes.NewValue(tftypes.String, nil),
+				"existing_id": tftypes.NewValue(tftypes.Number, 12345),
+			},
+		},
+		{
+			ExpectedError: false,
+			PlanValues: map[string]tftypes.Value{
+				"name":        tftypes.NewValue(tftypes.String, "my-pullzone"),
+				"existing_id": tftypes.NewValue(tftypes.Number, 12345),
+			},
+		},
+		{
+			ExpectedError: true,
+			PlanValues: map[string]tftypes.Value{
+				"name":        tftypes.NewValue(tftypes.String, nil),
+				"existing_id": tftypes.NewValue(tftypes.Number, nil),
+			},
+		},
+	}
+
+	configSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name":        schema.StringAttribute{},
+			"existing_id": schema.Int64Attribute{},
+		},
+	}
+
+	configTypes := tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"name":        tftypes.String,
+			"existing_id": tftypes.Number,
+		},
+	}
+
+	for _, testCase := range testCases {
+		request := resource.ValidateConfigRequest{
+			Config: tfsdk.Config{
+				Schema: configSchema,
+				Raw:    tftypes.NewValue(configTypes, testCase.PlanValues),
+			},
+		}
+
+		response := resource.ValidateConfigResponse{}
+		nameOrExistingIdValidator{}.ValidateResource(context.Background(), request, &response)
+
+		if testCase.ExpectedError && !response.Diagnostics.HasError() {
+			t.Error("expected error, got none")
+		}
+
+		if !testCase.ExpectedError && response.Diagnostics.HasError() {
+			t.Errorf("expected no errors, got %s", response.Diagnostics.Errors())
+		}
+	}
+}


### PR DESCRIPTION
When a DNS CNAME record uses accelerated = true, bunny auto-creates a pull zone. The new existing_id attribute allows managing that pull zone's settings without a manual import. Adopted pull zones are not deleted on destroy since the DNS record owns their lifecycle.

```terraform
resource "bunnynet_dns_zone" "example" {
  domain = "example.com"
}

resource "bunnynet_dns_record" "www" {
  zone        = bunnynet_dns_zone.example.id
  type        = "CNAME"
  name        = "www"
  value       = "example.com"
  accelerated = true
}

# Adopt the auto-created pull zone and configure it
resource "bunnynet_pullzone" "cdn" {
  existing_id = bunnynet_dns_record.www.accelerated_pullzone

  origin {
    type = "DnsAccelerate"
  }

  routing {
    tier = "Standard"
  }

  cache_enabled          = true
  cache_expiration_time  = 2592000
  cors_enabled           = true
}
```