### PR TITLE
Mark stream library api_key and provider api_key as sensitive

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -51,6 +51,7 @@ You can either set the API key directly on the <code>api_key</code> attribute fo
 			"api_key": schema.StringAttribute{
 				MarkdownDescription: "API key. Can also be set using the `BUNNYNET_API_KEY` environment variable.",
 				Optional:            true,
+				Sensitive:           true,
 			},
 			"api_url": schema.StringAttribute{
 				MarkdownDescription: "Optional. The API URL. Defaults to `https://api.bunny.net`.",

--- a/internal/provider/resource_stream_library.go
+++ b/internal/provider/resource_stream_library.go
@@ -164,7 +164,8 @@ func (r *StreamLibraryResource) Schema(ctx context.Context, req resource.SchemaR
 				Description: "The ID of the linked storage zone.",
 			},
 			"api_key": schema.StringAttribute{
-				Computed: true,
+				Computed:  true,
+				Sensitive: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},


### PR DESCRIPTION
These secret values were being rendered in plain text in terraform plan and apply output (e.g. CI logs), since the framework only redacts string attributes flagged Sensitive in the schema. Both fields are credentials returned from the bunny.net API and should be treated like the storage zone passwords, which are already marked sensitive.